### PR TITLE
Volume slider working

### DIFF
--- a/Globals/AudioManager/AudioManager.gd
+++ b/Globals/AudioManager/AudioManager.gd
@@ -1,0 +1,20 @@
+extends Node
+
+var SAVE_FILE_PATH = "res://settings.cfg"
+
+
+func _ready():
+	read_volume_from_config()
+		
+	
+func _on_volume_changed(var volume_ratio : float):
+	AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Master"), linear2db(volume_ratio))
+	
+
+func read_volume_from_config():
+	var config = ConfigFile.new()
+	
+	var err = config.load(SAVE_FILE_PATH)
+	if err == OK:
+		var ratio = config.get_value("audio", "volume") / 100
+		_on_volume_changed(ratio)

--- a/Scenes/MainMenu/OptionsSubmenu/OptionsSubmenu.gd
+++ b/Scenes/MainMenu/OptionsSubmenu/OptionsSubmenu.gd
@@ -7,7 +7,7 @@ var config: ConfigFile
 
 func _ready():
 	config = getConfigFile()
-	
+	 
 
 func show():
 	"""This overrides the default show() method."""
@@ -62,8 +62,11 @@ func _on_Cancel_pressed():
 	hide()
 	# reset initial values
 	setSceneValuesFromConfig(config)
+	AudioManager._on_volume_changed($VBoxContainer/Volume/HSlider.ratio)
 
 
 func _on_Ok_pressed():
 	hide()
 	saveConfig(config)
+	AudioManager._on_volume_changed($VBoxContainer/Volume/HSlider.ratio)
+	

--- a/project.godot
+++ b/project.godot
@@ -22,6 +22,7 @@ config/icon="res://icon.png"
 [autoload]
 
 SceneManager="*res://Globals/SceneManager/SceneManager.gd"
+AudioManager="*res://Globals/AudioManager/AudioManager.gd"
 
 [display]
 


### PR DESCRIPTION
The volume is set through audio bus when the volume slider is changed and option popup is closed. Also the volume is set on startup picking the value from config file if present otherwise default audio bus value will be used.

All audio related stuff is in autoloaded script called AudioManager.

Closes #60 