### PR TITLE
Add audio fade in-out

### DIFF
--- a/Scenes/Gameplay/Level.gd
+++ b/Scenes/Gameplay/Level.gd
@@ -8,6 +8,10 @@ func _ready():
 	#enable physics process on the spaceship
 	#once the level is ready
 	$Spaceship.set_physics_process(true)
+	$Spaceship.connect("gameOver", self, "fadeOutBackgroundMusic")
+	
+	$Tween.interpolate_property($BackgroundMusic, "volume_db", -80, 0, 1.50, Tween.TRANS_SINE, Tween.EASE_OUT, 0)
+	$Tween.start()
 
 
 func addShipDestroyedPoints():
@@ -22,3 +26,6 @@ func showMultiplier(multiplier):
 	$Score/Multiplier.text = str("x", multiplier)
 
 
+func fadeOutBackgroundMusic():
+	$Tween.interpolate_property($BackgroundMusic, "volume_db", 0, -80, 5.00, Tween.TRANS_SINE, Tween.EASE_IN, 0)
+	$Tween.start()

--- a/Scenes/Gameplay/Level1/Level1.tscn
+++ b/Scenes/Gameplay/Level1/Level1.tscn
@@ -88,8 +88,11 @@ valign = 1
 
 [node name="BackgroundMusic" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 6 )
+volume_db = -80.0
 autoplay = true
 
 [node name="HUD" parent="." instance=ExtResource( 7 )]
+
+[node name="Tween" type="Tween" parent="."]
 [connection signal="damage_taken" from="Spaceship" to="HUD" method="_on_Spaceship_damage_taken"]
 [connection signal="game_over" from="HUD" to="Spaceship" method="_on_game_over"]

--- a/Scenes/Main.gd
+++ b/Scenes/Main.gd
@@ -1,6 +1,10 @@
 extends Node2D
 
 
+func _ready():
+	$Tween.interpolate_property($AudioStreamPlayer, "volume_db", -40, 0, 1.00, Tween.TRANS_LINEAR, Tween.EASE_OUT, 0)
+	$Tween.start()
+
 func _on_AnimationPlayer_animation_finished(anim_name):
 	if anim_name == "spaceshipArrives":
 		$Spaceship/Sprite/AnimationPlayer.play("idle")
@@ -9,8 +13,8 @@ func _on_AnimationPlayer_animation_finished(anim_name):
 func _on_ScrollingBackground_transition_updated(completionPercentage, _moonXPos):
 	if completionPercentage > 0.55 and $Spaceship.modulate.a == 0:
 		$Spaceship/AnimationPlayer.play("spaceshipArrives")
-		
-		
+
+
 func _on_MainButtons_startGameClicked():
 	SceneManager.goto_scene("res://Scenes/Gameplay/Level1/Level1.tscn")
 

--- a/Scenes/Main.tscn
+++ b/Scenes/Main.tscn
@@ -106,7 +106,10 @@ anims/spaceshipArrives = SubResource( 1 )
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 10 )
+volume_db = -40.0
 autoplay = true
+
+[node name="Tween" type="Tween" parent="."]
 [connection signal="transition_updated" from="ScrollingBackground" to="." method="_on_ScrollingBackground_transition_updated"]
 [connection signal="transition_updated" from="ScrollingBackground" to="ScrollingFarBuildings" method="_on_ScrollingBackground_transition_updated"]
 [connection signal="transition_updated" from="ScrollingBackground" to="ScrollingBuildings" method="_on_ScrollingBackground_transition_updated"]

--- a/Scenes/Spaceship/Spaceship.gd
+++ b/Scenes/Spaceship/Spaceship.gd
@@ -1,5 +1,7 @@
 extends KinematicBody2D
 
+signal gameOver()
+
 onready var bullet_scene = preload("res://Scenes/Bullet/Bullet.tscn")
 onready var bullet_container = get_node("Bullets")
 onready var gun_node = get_node("Guns")
@@ -57,6 +59,7 @@ func _on_game_over():
 	$ExplosionParticleSystem/ExplosionSound.play()
 	$ExplosionParticleSystem.start_emission()
 	$Sprite.visible = false
+	emit_signal("gameOver")
 	yield(get_tree().create_timer(2.0), "timeout")
 	SceneManager.goto_scene("res://Scenes/Gameplay/Gameover/Gameover.tscn")
 	


### PR DESCRIPTION
First off, awesome repo idea, congratulations! :grinning: 

I'd never used Godot before and felt like tackling one of the issues, so I picked #94 .

I'm not sure if this is the best way to do it, but I implemented the fade in/out via tweening the `volume_db` property of the AudioStreamPlayers in the Main scene and Level1 as well.

One challenge was triggering the tween from the SpaceShip since the stream player belongs to the parent (level node), so I experimented with signals and they seemed to be a good fit.

I'm open to any and all feedback to improve this! Cheers! :)

---

Closes #94 