### PR TITLE
Spaceship controls disabled on final life loss

### DIFF
--- a/Scenes/Main.tscn
+++ b/Scenes/Main.tscn
@@ -52,7 +52,6 @@ tracks/2/keys = {
 }
 
 [node name="Main" type="Node2D"]
-editor/display_folded = true
 script = ExtResource( 1 )
 __meta__ = {
 "_edit_lock_": true
@@ -107,9 +106,9 @@ anims/spaceshipArrives = SubResource( 1 )
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 10 )
 autoplay = true
-[connection signal="transition_updated" from="ScrollingBackground" to="." method="_on_ScrollingBackground_transition_updated"]
-[connection signal="transition_updated" from="ScrollingBackground" to="ScrollingFarBuildings" method="_on_ScrollingBackground_transition_updated"]
 [connection signal="transition_updated" from="ScrollingBackground" to="ScrollingBuildings" method="_on_ScrollingBackground_transition_updated"]
+[connection signal="transition_updated" from="ScrollingBackground" to="ScrollingFarBuildings" method="_on_ScrollingBackground_transition_updated"]
+[connection signal="transition_updated" from="ScrollingBackground" to="." method="_on_ScrollingBackground_transition_updated"]
 [connection signal="transition_updated" from="ScrollingBackground" to="UILayer/MainButtons" method="_on_ScrollingBackground_transition_updated"]
 [connection signal="optionsButtonClicked" from="UILayer/MainButtons" to="UILayer" method="_on_MainButtons_optionsButtonClicked"]
 [connection signal="startGameClicked" from="UILayer/MainButtons" to="." method="_on_MainButtons_startGameClicked"]

--- a/Scenes/Spaceship/Spaceship.gd
+++ b/Scenes/Spaceship/Spaceship.gd
@@ -54,7 +54,6 @@ func _on_Recovery_Timer_timeout():
 
 func _on_game_over():
 	lives = 0 
-	print_debug("here")
 	current_state = State.DEAD
 	$ExplosionParticleSystem/ExplosionSound.play()
 	$ExplosionParticleSystem.start_emission()

--- a/Scenes/Spaceship/Spaceship.gd
+++ b/Scenes/Spaceship/Spaceship.gd
@@ -13,6 +13,7 @@ export(float, 0, 10, .5) var recovery_time = 3
 
 enum State {IDLE, RECOVERY, DEAD}
 export(State) var current_state = State.IDLE
+var lives = 5
 
 var next_shot = 0
 var guns_position = Vector2(100,35)
@@ -50,9 +51,10 @@ func _process(d):
 	
 func _on_Recovery_Timer_timeout():
 	current_state = State.IDLE
-	
-	
+
 func _on_game_over():
+	lives = 0 
+	print_debug("here")
 	current_state = State.DEAD
 	$ExplosionParticleSystem/ExplosionSound.play()
 	$ExplosionParticleSystem.start_emission()
@@ -62,7 +64,8 @@ func _on_game_over():
 	
 	
 func handle_collision():
-	if(current_state == State.IDLE):
+	if(lives != 0 && current_state == State.IDLE):
+		lives=lives-1
 		emit_signal("damage_taken")
 		recovery_timer.start()
 		current_state = State.RECOVERY
@@ -92,8 +95,10 @@ func init_controls():
 	var x_button = command_reference.instance()
 	x_button.command("X", KEY_X, "key")
 	$Inputs.add_child(x_button)
-	
+
 	 
+	
+	
 func init_recovery_timer():
 	recovery_timer.set_one_shot(true)
 	recovery_timer.set_wait_time(recovery_time)
@@ -109,20 +114,21 @@ func handle_damage_visual_effects():
 	
 	
 func handle_movement(d):
-	var direction = Vector2(0, 0)
-	if get_command("W").isPressed():
-		direction.y =- 1
-	if get_command("S").isPressed():
-		direction.y =+ 1
-	if get_command("A").isPressed():
-		direction.x =- 1
-	if get_command("D").isPressed():
-		direction.x =+ 1
-	
-	move_and_collide(direction * speed * d)
-	clamp_position_to_viewport_size()
+	if lives != 0:
+		var direction = Vector2(0, 0)
+		if get_command("W").isPressed():
+			direction.y =- 1
+		if get_command("S").isPressed():
+			direction.y =+ 1
+		if get_command("A").isPressed():
+			direction.x =- 1
+		if get_command("D").isPressed():
+			direction.x =+ 1
+		move_and_collide(direction * speed * d)
+		clamp_position_to_viewport_size()
 
 func clamp_position_to_viewport_size():
+
 	position.x = clamp(position.x, 0, viewport_size.x)
 	position.y = clamp(position.y, 0, viewport_size.y)
 
@@ -150,7 +156,7 @@ func decrease_next_shot_remaining_time(d):
 	
 func is_idle() -> bool:
 	return true if current_state == State.IDLE else false
-	
+
 
 func get_command(ID):
 	for cmd in $Inputs.get_children():


### PR DESCRIPTION
Implemented a lives variable in Spaceship.gd to keep track of the lives of the spaceship (Just mirrors the current_life_count in HUD.gd)
I dont particularly like the implementation as the number of lives should be in a single place and referenced from there.

But it solves the problem of being able to move your explosion around the screen. 